### PR TITLE
Hide Hackathons fix #525

### DIFF
--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -32,9 +32,9 @@ const NavBar = () => (
 				<LinkContainer to='/membership'>
 					<Nav.Link>Membership</Nav.Link>
 				</LinkContainer>
-				<LinkContainer to='/hackathons'>
+				{/* <LinkContainer to='/hackathons'>
 					<Nav.Link>Hackathons</Nav.Link>
-				</LinkContainer>
+				</LinkContainer> */}
 				<LinkContainer to='/contactus'>
 					<Nav.Link>Contact Us</Nav.Link>
 				</LinkContainer>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🔖 Release
- [ ] 🚩 Other


## Description

This PR adjusts the NavBar to hide the Hackathon page. 

## Related Tickets & Documents

Please use this format link issue numbers: Fixes #525 
https://github.com/CougarCS/CougarCS-Client/issues/525


## Mobile & Desktop Screenshots/Recordings

![Screen Shot 2022-09-02 at 9 20 49 AM](https://user-images.githubusercontent.com/75237411/188196914-24e22dfa-5705-4b26-89b4-ac7b5a9521ae.png)

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 readme
- [ ] 📜 contributing.md
- [x] 📓 docs
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?